### PR TITLE
fix error if PAYLOAD is not in response

### DIFF
--- a/api/gateway/paypal/wpp/nvpgateway.cfc
+++ b/api/gateway/paypal/wpp/nvpgateway.cfc
@@ -202,7 +202,7 @@
 		<!--- Mask the request data --->
 		<cfif getMasking() eq "on">
 			<cfset rd = response.getRequestData() />
-			<cfif isDefined("rd.PAYLOAD")>
+			<cfif isStruct(rd) AND structKeyExists(rd, "payload")>
 				<cfloop collection="#rd.PAYLOAD#" item="n">
 					<cfset rd.PAYLOAD[n] = mask(n, rd.PAYLOAD[n]) />
 				</cfloop>


### PR DESCRIPTION
I had implemented a search() method in nvpgateway.cfc. It was erroring when calling process(). I traced it and found that the response was coming back empty, i.e. Payload did not exist in the response. This fixed the problem. 
