### PR TITLE
Treat "SuccessWithWarning" as a successful charge.

### DIFF
--- a/api/gateway/paypal/wpp/nvpgateway.cfc
+++ b/api/gateway/paypal/wpp/nvpgateway.cfc
@@ -174,7 +174,7 @@
 				<cfif structKeyExists(results, "L_LONGMESSAGE0")>
 					<cfset response.setMessage(results.L_LONGMESSAGE0) />
 				</cfif>
-			<cfelseif results.ACK eq "Success">
+			<cfelseif results.ACK eq "Success" OR results.ACK eq "SuccessWithWarning">
 				<cfset response.setStatus(getService().getStatusSuccessful()) />
 
 


### PR DESCRIPTION
Without this code change cfpayment will return false for getSuccess() even though the credit card was charged successfully through PayPal (nvp).